### PR TITLE
Add, and maintain, basics-extra repository

### DIFF
--- a/maintainers.md
+++ b/maintainers.md
@@ -33,4 +33,4 @@ This file contains info on elm-community packages and who the current maintainer
 | [elm-shrink](http://github.com/elm-community/elm-shrink) | Shrink a value to a simpler one | mgold |  maxgoldstein1@gmail.com |
 | [elm-test](http://github.com/elm-community/elm-test) | A unit testing framework for Elm | eeue56 | enalicho@gmail.com |
 | [elm-check](http://github.com/elm-community/elm-check) | Property-based testing | mgold |  maxgoldstein1@gmail.com |
-
+| [basics-extra](http://github.com/elm-community/basics-extra) | Additional basic functions | jvoigtlaender |  janis.voigtlaender@gmail.com |


### PR DESCRIPTION
I'd add an `elm-community/basics-extra` repository. The first contribution to cover would be https://github.com/elm-lang/core/pull/593.
