### PR TITLE
Request to maintain elm-webgl

### DIFF
--- a/maintainers.md
+++ b/maintainers.md
@@ -5,7 +5,7 @@ This file contains info on elm-community packages and who the current maintainer
 | Repo | Description | Maintainer github | Maintainer email |
 |------|-------|----------|-------|--------|-------------|
 | [builtwithelm](http://github.com/elm-community/builtwithelm) | A list of projects and apps built with Elm. | lukewestby | opensource@lukewestby.com  |
-| [elm-webgl](http://github.com/elm-community/elm-webgl) | Functional 3D Rendering with WebGL in Elm | *Unmaintained* |  |
+| [elm-webgl](http://github.com/elm-community/elm-webgl) | Functional 3D Rendering with WebGL in Elm | w0rm | unsoundscapes@gmail.com |
 | [elm-list-extra](http://github.com/elm-community/elm-list-extra) | Convenience functions for working with List | abadi199 | abadi.kurniawan@gmail.com |
 | [elm-history](http://github.com/elm-community/elm-history) | Elm bindings to HTML5 History API | *Unmaintained* |  |
 | [elm-compiler-docs](http://github.com/elm-community/elm-compiler-docs) | Repo where to write down documentation and guides for the elm-compiler | mgold | maxgoldstein1@gmail.com |


### PR DESCRIPTION
I would like to take over elm-webgl. I have a couple of projects that depend on it and so I would like to move it forward.

These are my plans (will create issues):
1. Update all examples to work with 0.17
2. Drop dependency on Element, provide toHtml method out of box
3. Add support to disable premultipliedAlpha, so hacks [like this](https://github.com/zalando/elm-street-404/commit/ce7c84530c7f194c42518773f79716571f03c48e) won't be necessary
4. Extract a task to load an image and measure its size into the separate module, this may be helpful outside of webgl
