### PR TITLE
Add myself as a maintainer of webgl

### DIFF
--- a/maintainers.md
+++ b/maintainers.md
@@ -5,7 +5,7 @@ This file contains info on elm-community packages and who the current maintainer
 | Repo | Description | Maintainer github | Maintainer email |
 |------|-------|----------|-------|--------|-------------|
 | [builtwithelm](http://github.com/elm-community/builtwithelm) | A list of projects and apps built with Elm. | lukewestby | opensource@lukewestby.com  |
-| [elm-webgl](http://github.com/elm-community/elm-webgl) | Functional 3D Rendering with WebGL in Elm | *Unmaintained* |  |
+| [webgl](http://github.com/elm-community/webgl) | Functional 3D Rendering with WebGL in Elm | w0rm | unsoundscapes@gmail.com |
 | [list-extra](http://github.com/elm-community/list-extra) | Convenience functions for working with List | abadi199 | abadi.kurniawan@gmail.com |
 | [elm-compiler-docs](http://github.com/elm-community/elm-compiler-docs) | Repo where to write down documentation and guides for the elm-compiler | mgold | maxgoldstein1@gmail.com |
 | [json-extra](http://github.com/elm-community/json-extra) | Convenience functions for working with Json | lukewestby | opensource@lukewestby.com |
@@ -17,7 +17,7 @@ This file contains info on elm-community packages and who the current maintainer
 | [elm-faq](http://github.com/elm-community/elm-faq) | FAQ about the Elm language | fredcy | fredcy@gmail.com  |
 | [html-extra](http://github.com/elm-community/html-extra) | Additional functions for working with Html | *Unmaintained* |  |
 | [elm-for-js](http://github.com/elm-community/elm-for-js) | Community driven Elm guide for JS people | *Unmaintained* |  |
-| [linear-algebra](http://github.com/elm-community/linear-algebra) | Enough linear algebra to support elm-webgl | fredcy | fredcy@gmail.com |
+| [linear-algebra](http://github.com/elm-community/linear-algebra) | Enough linear algebra to support webgl | fredcy | fredcy@gmail.com |
 | [undo-redo](http://github.com/elm-community/undo-redo) | Easy undo in Elm | rohanorton | rohan.orton@gmail.com |
 | [list-split](http://github.com/elm-community/list-split) | Split lists into chunks | jonboiser | jonboiser@outlook.com  |
 | [elm-lang.org](http://github.com/elm-community/elm-lang.org) | The full source for http://elm-lang.org/, the home-page of the Elm programming language. Open sourced as a way to teach people how to write and serve Elm code. Follow the instructions in README.md to get the site setup on your own machine. | *Unmaintained* |  |


### PR DESCRIPTION
Hello, 

As I'm currently porting the library to Elm 0.18, I would like to become a maintainer of [webgl](https://github.com/elm-community/webgl).

I understand that we can't easily add lots of new features, but at least we can keep the existing stuff working. e.g. I have a few projects https://github.com/w0rm/elm-mogee and https://github.com/zalando/elm-street-404 that rely on this library. 
