### PR TITLE
Add @prikhi as html-extra Maintainer

### DIFF
--- a/maintainers.md
+++ b/maintainers.md
@@ -15,7 +15,7 @@ This file contains info on elm-community packages and who the current maintainer
 | [result-extra](http://github.com/elm-community/result-extra) | Convenience functions for working with Result | abadi199 | abadi.kurniawan@gmail.com |
 | [elm-material-icons](http://github.com/elm-community/elm-material-icons) | Material Icons in Elm | mgold | maxgoldstein1@gmail.com |
 | [elm-faq](http://github.com/elm-community/elm-faq) | FAQ about the Elm language | fredcy | fredcy@gmail.com  |
-| [html-extra](http://github.com/elm-community/html-extra) | Additional functions for working with Html | *Unmaintained* |  |
+| [html-extra](http://github.com/elm-community/html-extra) | Additional functions for working with Html | prikhi | pavan.rikhi@gmail.com  |
 | [elm-for-js](http://github.com/elm-community/elm-for-js) | Community driven Elm guide for JS people | *Unmaintained* |  |
 | [linear-algebra](http://github.com/elm-community/linear-algebra) | Enough linear algebra to support webgl | fredcy | fredcy@gmail.com |
 | [undo-redo](http://github.com/elm-community/undo-redo) | Easy undo in Elm | rohanorton | rohan.orton@gmail.com |


### PR DESCRIPTION
I would like to take over maintenance of the html-extra package.

Not sure if there are necessary qualifications, but I have a couple Elm projects under my belt & am pretty active on Slack:
https://github.com/Southern-Exposure-Seed-Exchange/Order-Manager-Prototypes/tree/master/elm/
https://github.com/prikhi/bodyweight-client
https://github.com/prikhi/RSSonate

Let me know if you'd like any more information.