### PR TITLE
Adding myself as maintainer to a new project called Canvas

### DIFF
--- a/maintainers.md
+++ b/maintainers.md
@@ -35,6 +35,7 @@ This file contains info on elm-community packages and who the current maintainer
 | [string-extra](http://github.com/elm-community/string-extra) | String helper functions for Elm | lorenzo & jaapz | jose.zap@gmail.com & jaapz.b@gmail.com |
 | [ratio](http://github.com/elm-community/ratio) | Rational numbers | newlandsvalley | john.watson@gmx.co.uk |
 | [elm-webpack-loader](https://github.com/elm-community/elm-webpack-loader) | Webpack loader for Elm | eeue56 | enalicho@gmail.com |
+| [canvas](https://github.com/elm-community/canvas) | Canvas API | chadtech | chadtech@programhouse.us |
 
 ## Deprecated packages
 | Repo | Description | Maintainer github | Maintainer email |


### PR DESCRIPTION
Hey folks,

I made a PR about adding myself as a maintainer to a project called Canvas (Or 'Elm-Canvas'). We had a bit of a conversation and @jvoigtlaender suggested I reference the yet-to-exist `elm-community/canvas` repo rather than `chadtech/elm-canvas`. That makes sense to me, and thats what this PR is.