### PR TITLE
Deprecate datepicker

### DIFF
--- a/maintainers.md
+++ b/maintainers.md
@@ -13,7 +13,6 @@ This file contains info on elm-community packages and who the current maintainer
 | [elm-combine](http://github.com/elm-community/elm-combine/) | A parser combinator library. | stil4m | mstijlaart@gmail.com |
 | [elm-community.github.io](http://github.com/elm-community/elm-community.github.io) | Elm Community organization pages | *Unmaintained* |  |
 | [elm-compiler-docs](http://github.com/elm-community/elm-compiler-docs) | Repo where to write down documentation and guides for the elm-compiler | mgold | maxgoldstein1@gmail.com |
-| [elm-datepicker](http://github.com/elm-community/elm-datepicker) | A reusable date picker component in Elm. | bbqbaron | eric.r.loren@gmail.com |
 | [elm-faq](http://github.com/elm-community/elm-faq) | FAQ about the Elm language | fredcy | fredcy@gmail.com |
 | [elm-for-js](http://github.com/elm-community/elm-for-js) | Community driven Elm guide for JS people | *Unmaintained* |  |
 | [elm-route](https://github.com/elm-community/elm-route) | Route parser for Elm | gjaldon | gjaldon85@gmail.com |
@@ -46,5 +45,6 @@ This file contains info on elm-community packages and who the current maintainer
 ## Deprecated packages
 | Repo | Description | Maintainer github | Maintainer email |
 |------|-------|----------|-------|
+| [elm-datepicker](http://github.com/elm-community/elm-datepicker) | A reusable date picker component in Elm. 0.19 fork hosted by [CurrySoftware](https://github.com/CurrySoftware/elm-datepicker) | bbqbaron | eric.r.loren@gmail.com |
 | [elm-history](http://github.com/elm-community/elm-history) | Elm bindings to HTML5 History API | *Unmaintained* |  |
 | [elm-lang.org](http://github.com/elm-community/elm-lang.org) | The full source for http://elm-lang.org/, the home-page of the Elm programming language. Open sourced as a way to teach people how to write and serve Elm code. Follow the instructions in README.md to get the site setup on your own machine. | *Unmaintained* |  |


### PR DESCRIPTION
As of 0.19, Elm doesn't have a default datepicker. Moved the lib to deprecated and noted that 0.19 support is being assumed by a fork, linked in the description.