### PR TITLE
Move TSFoster/elm-bytes-extra to elm-community/bytes-extra

### DIFF
--- a/maintainers.md
+++ b/maintainers.md
@@ -7,6 +7,7 @@ This file contains info on elm-community packages and who the current maintainer
 | [array-extra](http://github.com/elm-community/array-extra) | Convenience functions for working with Array | jonboiser | jonboiser@outlook.com |
 | [basics-extra](http://github.com/elm-community/basics-extra) | Additional basic functions | pzp1997 | pzpaul2002@yahoo.com |
 | [builtwithelm](http://github.com/elm-community/builtwithelm) | A list of projects and apps built with Elm | prikhi | pavan.rikhi@gmail.com |
+| [bytes-extra](http://github.com/elm-community/bytes-extra) | Convenience functions for working with Bytes | TSFoster | hi@tsf.io |
 | [dict-extra](http://github.com/elm-community/dict-extra) | A library with extra functions for the dictionary type in elm core | Skinney | robin.heggelund@icloud.com |
 | [easing-functions](https://github.com/elm-community/easing-functions) | Easing (animation and timing) library for Elm | Dandandan | danielheres@gmail.com |
 | [elm-check](http://github.com/elm-community/elm-check) | Property-based testing | mgold | maxgoldstein1@gmail.com |


### PR DESCRIPTION
Hi,

I'd like to move [TSFoster/elm-bytes-extra](https://github.com/TSFoster/elm-bytes-extra) over to this org, if it seems like a good idea to you all. It's the only bytes-extra package published, and I think it makes sense for it to be a community-led package.