### PR TITLE
Move y0hy0h/ordered-containers to elm-community/ordered-containers

### DIFF
--- a/maintainers.md
+++ b/maintainers.md
@@ -31,6 +31,7 @@ This file contains info on elm-community packages and who the current maintainer
 | [list-split](http://github.com/elm-community/list-split) | Split lists into chunks | jonboiser | jonboiser@outlook.com |
 | [material-icons](http://github.com/elm-community/material-icons) | Material Icons in Elm | mgold | maxgoldstein1@gmail.com |
 | [maybe-extra](http://github.com/elm-community/maybe-extra) | Convenience functions for working with Maybe | skyqrose | btgtcmxh@sky.skyqrose.com |
+| [ordered-containers](http://github.com/elm-community/maybe-extra) | OrderedDict and OrderedSet that remember the order of insertion | y0hy0h | y0hy0h@gmx.net |
 | [random-extra](http://github.com/elm-community/random-extra) | Extra functions for Random | mgold | maxgoldstein1@gmail.com |
 | [ratio](http://github.com/elm-community/ratio) | Rational numbers | newlandsvalley | john.watson@gmx.co.uk |
 | [result-extra](http://github.com/elm-community/result-extra) | Convenience functions for working with Result | prikhi | pavan.rikhi@gmail.com |

--- a/maintainers.md
+++ b/maintainers.md
@@ -31,7 +31,7 @@ This file contains info on elm-community packages and who the current maintainer
 | [list-split](http://github.com/elm-community/list-split) | Split lists into chunks | jonboiser | jonboiser@outlook.com |
 | [material-icons](http://github.com/elm-community/material-icons) | Material Icons in Elm | mgold | maxgoldstein1@gmail.com |
 | [maybe-extra](http://github.com/elm-community/maybe-extra) | Convenience functions for working with Maybe | skyqrose | btgtcmxh@sky.skyqrose.com |
-| [ordered-containers](http://github.com/elm-community/maybe-extra) | OrderedDict and OrderedSet that remember the order of insertion | y0hy0h | y0hy0h@gmx.net |
+| [ordered-containers](http://github.com/elm-community/ordered-containers) | OrderedDict and OrderedSet that remember the order of insertion | y0hy0h | y0hy0h@gmx.net |
 | [random-extra](http://github.com/elm-community/random-extra) | Extra functions for Random | mgold | maxgoldstein1@gmail.com |
 | [ratio](http://github.com/elm-community/ratio) | Rational numbers | newlandsvalley | john.watson@gmx.co.uk |
 | [result-extra](http://github.com/elm-community/result-extra) | Convenience functions for working with Result | prikhi | pavan.rikhi@gmail.com |


### PR DESCRIPTION
I'd like to request my repository [ordered-containers](https://github.com/Y0hy0h/ordered-containers/tree/elm-ordered-containers) to be moved to elm-community.

Note that the above links to a branch on which I have reworked the code to merge with https://github.com/wittjosiah/elm-ordered-dict and also to explicitly documented handling of re-insertion. The goal would be to publish that branch as elm-community/ordered-containers v1.0.0.

I have added myself as the maintainer. But if someone else is interested, they can gladly take that role!