### PR TITLE
Add `lue-bird` as maintainer of `array-extra`

### DIFF
--- a/maintainers.md
+++ b/maintainers.md
@@ -4,7 +4,7 @@ This file contains info on elm-community packages and who the current maintainer
 ## Repo breakdown (in alphabetic order)
 | Repo | Description | Maintainer github | Maintainer email |
 |------|-------|----------|-------|
-| [array-extra](http://github.com/elm-community/array-extra) | Convenience functions for working with Array | jonboiser | jonboiser@outlook.com |
+| [array-extra](http://github.com/elm-community/array-extra) | Convenience functions for working with Array | lue-bird, jonboiser | lue.the.bird@gmail.com, jonboiser@outlook.com |
 | [basics-extra](http://github.com/elm-community/basics-extra) | Additional basic functions | pzp1997 | pzpaul2002@yahoo.com |
 | [builtwithelm](http://github.com/elm-community/builtwithelm) | A list of projects and apps built with Elm | prikhi | pavan.rikhi@gmail.com |
 | [dict-extra](http://github.com/elm-community/dict-extra) | A library with extra functions for the dictionary type in elm core | Skinney | robin.heggelund@icloud.com |


### PR DESCRIPTION
https://github.com/elm-community/array-extra/pull/21#issuecomment-817129637

@indique says they can help maintain array-extra under their handle @lue-bird

the PR above adds some nice performance gains to the library, and lue-bird says they can improve the repo with some new tests and a nicer array API 👍 